### PR TITLE
Death to injectors

### DIFF
--- a/recipes/FoxxAuth.md
+++ b/recipes/FoxxAuth.md
@@ -40,7 +40,7 @@ controller.post('/register', function(req, res) {
     username: username,
     password: password
   });
-}).bodyParam('credentials', 'Username and Password', Credentials);
+}).bodyParam('credentials', {description: 'Username and Password', type: Credentials});
 ```
 
 Now we need to have a place to store users. In order to do that, we will use the functionality of two other foxx applications by requiring them. We're loading the exported APIs of the built-in user and auth apps (we will see what that means in a minute). Like the built-in sessions app, a copy of the user and auth apps are automatically mounted at these mount points by ArangoDB. So all we do in our controller is the following:
@@ -169,7 +169,7 @@ controller.post('/login', function (req, res) {
   res.json({
     msg: 'Welcome ' + user.get('user')
   });
-}).bodyParam('credentials', 'Username and Password', Credentials)
+}).bodyParam('credentials', {description: 'Username and Password', type: Credentials})
   .errorResponse(NotLoggedIn, 401, 'Login failed');
 ```
 

--- a/recipes/FoxxAuth.md
+++ b/recipes/FoxxAuth.md
@@ -43,7 +43,7 @@ controller.post('/register', function(req, res) {
 }).bodyParam('credentials', 'Username and Password', Credentials);
 ```
 
-Now we need to have a place to store users. In order to do that, we will use the functionality of two other foxx applications by first requiring them and then injecting them. We're loading the exported APIs of the built-in user and auth apps (we will see what that means in a minute). Like the built-in sessions app, a copy of the user and auth apps are automatically mounted at these mount points by ArangoDB. So all we do in our controller is the following:
+Now we need to have a place to store users. In order to do that, we will use the functionality of two other foxx applications by requiring them. We're loading the exported APIs of the built-in user and auth apps (we will see what that means in a minute). Like the built-in sessions app, a copy of the user and auth apps are automatically mounted at these mount points by ArangoDB. So all we do in our controller is the following:
 
 ```js
 var auth = Foxx.requireApp('/_system/simple-auth').auth,
@@ -161,7 +161,7 @@ Let's use this in a new login route:
 ```js
 var login = require('./util/auth').login;
 
-controller.post('/login', function (req, res, injected) {
+controller.post('/login', function (req, res) {
   var credentials = req.params('credentials'),
     user = login(credentials, req.session);
 

--- a/recipes/FoxxAuth.md
+++ b/recipes/FoxxAuth.md
@@ -43,99 +43,83 @@ controller.post('/register', function(req, res) {
 }).bodyParam('credentials', 'Username and Password', Credentials);
 ```
 
-Now we need to have a place to store users. In order to do that, we will use the functionality of two other foxx applications by first requiring them and then injecting them. We're injecting the exported APIs of the built-in user and auth apps into our controller (we will see what that means in a minute). Like the built-in sessions app, a copy of the user and auth apps are automatically mounted at these mount points by ArangoDB. So all we do in our controller is the following:
+Now we need to have a place to store users. In order to do that, we will use the functionality of two other foxx applications by first requiring them and then injecting them. We're loading the exported APIs of the built-in user and auth apps (we will see what that means in a minute). Like the built-in sessions app, a copy of the user and auth apps are automatically mounted at these mount points by ArangoDB. So all we do in our controller is the following:
 
 ```js
-controller.addInjector({
-  auth: function() { return Foxx.requireApp('/_system/simple-auth').auth; },
-  users: function() { return Foxx.requireApp('/_system/users').userStorage; }
-});
+var auth = Foxx.requireApp('/_system/simple-auth').auth,
+  users = Foxx.requireApp('/_system/users').userStorage;
 ```
 
-As a result of that our actions now get a third parameter which is an object with the objects we injected -- in our case `auth` and `users`. Let's use the authentication app to hash and salt our password:
+We can now use the exports of the two other Foxx apps as `auth` and `users`. Let's use the authentication app to hash and salt our password:
 
 ```js
-controller.post('/register', function(req, res, injected) {
+controller.post('/register', function(req, res) {
   var credentials = req.params('credentials'),
     username = credentials.get('username'),
-    password = injected.auth.hashPassword(credentials.get('password'));
+    password = auth.hashPassword(credentials.get('password'));
 
   res.status(201);
   res.json({
     username: username,
     password: password
   });
-}).bodyParam('credentials', 'Username and Password', Credentials);
+}).bodyParam('credentials', {description: 'Username and Password', type: Credentials});
 ```
 
-Great! Now let's use our users app to store a new user. The injected `users` object has a create method which takes three arguments: The username, a user profile (which we will leave empty for now) and a password object. Let's create a user:
+Great! Now let's use our users app to store a new user. The `users` object has a create method which takes three arguments: The username, a user profile (which we will leave empty for now) and a password object. Let's create a user:
 
 ```js
-controller.post('/register', function(req, res, injected) {
+controller.post('/register', function(req, res) {
   var credentials = req.params('credentials'),
     username = credentials.get('username'),
-    password = injected.auth.hashPassword(credentials.get('password')),
+    password = auth.hashPassword(credentials.get('password')),
     user;
 
-  user = injected.users.create(username, {}, { simple: password });
+  user = users.create(username, {}, { simple: password });
 
   res.status(201);
   res.json({
     username: username
   });
-}).bodyParam('credentials', 'Username and Password', Credentials);
+}).bodyParam('credentials', {description: 'Username and Password', type: Credentials});
 ```
 
 Now create a user with username and password via the route. To see the created user, we will look into the user collection of ArangoDB. First, go to the collections tab. It is a system collection, so we first need to show system collections by clicking on the cogwheel and activating system collections. Then click on the collection users and you will see your new users. Great!
 
-Now let's clean this up a little. We want to have a repository-like structure that will create users for us and do hashing etc. As this requires the two other applications, we have to inject it. Let's create an `injectors` folder and create a `users.js` file there:
+Now let's clean this up a little. We want to have a helper function that will create users for us and do hashing etc. Let's create a `util` folder and create an `auth.js` file there:
 
 ```js
 var _ = require('underscore'),
   Foxx = require('org/arangodb/foxx'),
-  UsersRepository,
-  injectUsers;
+  auth = Foxx.requireApp('/_system/simple-auth').auth,
+  users = Foxx.requireApp('/_system/users').userStorage;
 
-UsersRepository = function () {
-  this.auth = Foxx.requireApp('/_system/simple-auth').auth;
-  this.users = Foxx.requireApp('/_system/users').userStorage;
-};
+function createUser(credentials) {
+  var password = auth.hashPassword(credentials.get('password'));
+  return users.create(credentials.get('username'), {}, { simple: password });
+}
 
-_.extend(UsersRepository.prototype, {
-  create: function (credentials) {
-    var password = this.auth.hashPassword(credentials.get('password'));
-    return this.users.create(credentials.get('username'), {}, { simple: password });
-  }
-});
-
-injectUsers = function () {
-  var usersRepository = new UsersRepository();
-  return usersRepository;
-};
-
-exports.injectUsers = injectUsers;
+exports.createUser = createUser;
 ```
 
-This will export an injector function, that we can now use instead of the other two injections:
+This will export a function, that we can now use instead of the other two imports:
 
 ```js
-controller.addInjector({
-  users: injectUsers
-});
+var createUser = require('./util/auth').createUser;
 ```
 
 And now we can simplify our controller:
 
 ```js
-controller.post('/register', function(req, res, injected) {
+controller.post('/register', function(req, res) {
   var credentials = req.params('credentials'),
-    user = injected.users.create(credentials);
+    user = createUser(credentials);
 
   res.status(201);
   res.json({
     username: user.get('user')
   });
-}).bodyParam('credentials', 'Username and Password', Credentials);
+}).bodyParam('credentials', {description: 'Username and Password', type: Credentials});
 ```
 
 We now have a dedicated place to handle creating and searching for users. It is also a good place for raising exceptions if something goes wrong -- for example if the user is not found. In that case we would catch the exception from the module and translate it into our own, application specific error that we can then add as an errorReponse to the routes in our FoxxController. It is also a good place to put our code to find a user by his or her credentials. But first we need to activate sessions for this controller (in your app, the cookie secret should be something app-specific, **really secret**):
@@ -144,17 +128,17 @@ We now have a dedicated place to handle creating and searching for users. It is 
 controller.activateSessions({
   type: 'cookie',
   cookie: {
-    secret: 'secret'
+    secret: 'keep this secret'
   }
 });
 ```
 
-Now we can add another method to our injector to log in a user. It will take the provided credentials and the session. It will throw an error when the credentials are not valid (you can create a file `not_logged_in.js` in an `error` folder and require it from both here and the controller) -- otherwise it will set the session data and return the user.
+Now we can add another utility function to log in a user. It will take the provided credentials and the session. It will throw an error when the credentials are not valid (you can create a file `not-logged-in.js` in an `error` folder and require it from both here and the controller) -- otherwise it will set the session data and return the user.
 
 ```js
-login: function (credentials, session) {
-  var user = this.users.resolve(credentials.get('username'));
-  var valid = this.auth.verifyPassword(
+function login(credentials, session) {
+  var user = users.resolve(credentials.get('username'));
+  var valid = auth.verifyPassword(
     user ? user.get('authData').simple : {},
     credentials.get('password')
   );
@@ -168,14 +152,18 @@ login: function (credentials, session) {
   session.save();
   return user;
 }
+
+exports.login = login;
 ```
 
 Let's use this in a new login route:
 
 ```js
+var login = require('./util/auth').login;
+
 controller.post('/login', function (req, res, injected) {
   var credentials = req.params('credentials'),
-    user = injected.users.login(credentials, req.session);
+    user = login(credentials, req.session);
 
   res.status(201);
   res.json({


### PR DESCRIPTION
Remove Dependency Injectors for 2.5.

Should the old version be retained as `FoxxAuthLegacy` for 2.4 and lower? This doesn't work in 2.4, I think.

@mchacki 