### PR TITLE
Don't use legacy syntax

### DIFF
--- a/recipes/FoxxFirstSteps.md
+++ b/recipes/FoxxFirstSteps.md
@@ -135,7 +135,7 @@ controller.post('/', function (req, res) {
   var todo = req.params('todo');
   todos.save(todo);
   res.json(todo.forClient());
-}).bodyParam('todo', 'The Todo you want to create', Todo);
+}).bodyParam('todo', {description: 'The Todo you want to create', type: Todo});
 ```
 
 

--- a/recipes/FoxxQueues.md
+++ b/recipes/FoxxQueues.md
@@ -28,7 +28,7 @@ controller.post('/', function (req, res) {
     subject: 'New Todo Added',
     html: 'New Todo added: ' + todo.get('title')
   });
-}).bodyParam('todo', 'The Todo you want to create', Todo);
+}).bodyParam('todo', {description: 'The Todo you want to create', type: Todo});
 ```
 
 And that's it! To try it out open your todo app from the Applications tab in the ArangoDB web interface and create a new todo item with the interactive documentation. You will receive an email with the title of the todo shortly after that. As we are using the queue, the user of your API doesn't need to wait until the email is sent, but gets an immediate answer.


### PR DESCRIPTION
The legacy syntax was deprecated in 2.4 and removed in 2.5. The new syntax should already be available in 2.2 or 2.3.