### PR TITLE
Replace anchorjs plugin, fix link

### DIFF
--- a/recipes/UseCases/CrawlingGithubPromises.md
+++ b/recipes/UseCases/CrawlingGithubPromises.md
@@ -194,4 +194,4 @@ The source code of this example is available from Github: <https://github.com/fc
 [2]: https://www.npmjs.com/package/promises
 [3]: https://github.com/fceller/Foxxmender
 [4]: https://github.com/arangodb/queue-it
-[5]: [Running in a Docker container](../Cloud/DockerContainer.md)
+[5]: ../Cloud/DockerContainer.md

--- a/recipes/book.json
+++ b/recipes/book.json
@@ -4,7 +4,7 @@
   "author": "ArangoDB GmbH",
   "description": "Recipes for ArangoDB - the multi-model NoSQL database",
   "language": "en",
-  "plugins":["-search", "-sharing", "toggle-chapters", "addcssjs", "heading-anchors", "add-header", "piwik"],
+  "plugins":["-search", "-sharing", "toggle-chapters", "addcssjs", "anchorjs", "add-header", "piwik"],
   "pdf": {
     "fontSize": 12,
     "toc": true,


### PR DESCRIPTION
Adapted heading-anchors plugin to use more recent anchor.js version and move configuration options to `book.json` (not used by us so far).