### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ In this cookbook you can find some recipes for specific problems regarding Arang
 
 The cookbook is always work in progress.
 
-##How to contribute
+## How to contribute
 
 Do you have recipes for the ArangoDB cookbook?  <br>
 Write them down and we will add them!
@@ -27,7 +27,7 @@ here: https://www.arangodb.com/documents/cla.pdf
 Please fill out and sign the CLA, then scan and email it to cla (at) arangodb.com -
 we will add your recipe as soon as possible after receiving it.
 
-##How to build the cookbook locally
+## How to build the cookbook locally
 
 If you want to build and test the cookbook on your local computer, perform the
 following steps (in a terminal / command line):

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -5,7 +5,7 @@ and to help you with specific problems.
 
 You can participate and [write your own recipes][2]. You only need to write a recipe in markdown and make a [pull request to our repository][2]. 
 
-##Recipes
+## Recipes
 
 There will be some simple recipes to bring you closer to ArangoDB and show you the amount of possibilities
 of our Database. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
