### PR TITLE
The /_api route must be accessible and it requires web server configuration

### DIFF
--- a/recipes/MakingFoxxAppAccessible.md
+++ b/recipes/MakingFoxxAppAccessible.md
@@ -130,7 +130,7 @@ curl --dump - http://your.domain.com/
 If that's still working, check if ArangoDB is still accessible from the outside:
 
 ```
-curl --dump - http://your.domain.com/_api/version
+curl --dump - http://your.domain.com:8529/_api/version
 ```
 
 This should **not** work. If curl hangs or aborts with an error, that's good news.

--- a/recipes/MakingFoxxAppAccessible.md
+++ b/recipes/MakingFoxxAppAccessible.md
@@ -84,6 +84,9 @@ ProxyPass /arangodb/ http://127.0.0.1:8529/
 ProxyPassReverse /arangodb/ http://127.0.0.1:8529/
 ProxyPass /_db/ http://127.0.0.1:8529/_db/
 ProxyPassReverse /_db/ http://127.0.0.1:8529/_db/
+ProxyPass /_api/ http://127.0.0.1:8529/_api/
+ProxyPassReverse /_api/ http://127.0.0.1:8529/_api/
+
 ```
 
 Restart Apache again.
@@ -108,6 +111,10 @@ Respectively the availability to the Managementconsole:
            allow all;
            proxy_pass http://127.0.0.1:8529/_db;
         }
+        location /_api {
+           allow all;
+           proxy_pass http://127.0.0.1:8529/_api;
+        }
 
 ### Validate the accessibility
 
@@ -123,7 +130,7 @@ curl --dump - http://your.domain.com/
 If that's still working, check if ArangoDB is still accessible from the outside:
 
 ```
-curl --dump - http://your.domain.com:8529/_api/version
+curl --dump - http://your.domain.com/_api/version
 ```
 
 This should **not** work. If curl hangs or aborts with an error, that's good news.


### PR DESCRIPTION
The `/_api` is used by administation interface, without that accessing the "Users" tab on administation interface from internet will not work.

I think this recipe must to be inserted in 3.x Cookbook to avoid misconfiguration .

This solve this issue: https://github.com/arangodb/arangodb/issues/2414
